### PR TITLE
Remove the use of negative lookaround

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,19 @@ const visit = require('unist-util-visit');
 
 module.exports = rule('remark-lint:prohibited-strings', prohibitedStrings);
 
+function testProhibited(val, content) {
+  const re = new RegExp(`(\\.)?${val.no}(\\.\\w)?`, 'g');
+
+  let result = null;
+  while (result = re.exec(content)) {
+    if (!result[1] && !result[2]) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function prohibitedStrings(ast, file, strings) {
   visit(ast, 'text', checkText);
 
@@ -12,8 +25,7 @@ function prohibitedStrings(ast, file, strings) {
     const content = node.value;
 
     strings.forEach((val) => {
-      const re = new RegExp(`(?<!\\.)${val.no}(?!\\.\\w)`);
-      if (re.test(content)) {
+      if (testProhibited(val, content)) {
         file.message(`Use "${val.yes}" instead of "${val.no}"`, node);
       }
     });

--- a/test.js
+++ b/test.js
@@ -77,5 +77,16 @@ test('remark-lint-prohibited-strings', (t) => {
       'should flag prohibited string if it is followed by . alone'
     );
   }
+
+  {
+    const contents = 'The fhqwhgads.v8 page for the band v8 rocks.';
+    t.deepEqual(
+      processorWithOptions([{ yes: 'V8', no: 'v8' }])
+        .processSync(vfile({ path: path, contents: contents }))
+        .messages.map(String),
+      [ 'fhqwhgads.md:1:1-1:45: Use "V8" instead of "v8"' ],
+      'should flag prohibited string even if an allowed usage precedes it'
+    );
+  }
   t.end();
 });


### PR DESCRIPTION
Negative lookaround isn't currently supported in node 8 or
node-chakracore. The workaround is to match on the surrounding
characters and detect them in code.