### PR TITLE
fix: handle punctuation at start/end of "no" strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,20 @@ const visit = require('unist-util-visit');
 module.exports = rule('remark-lint:prohibited-strings', prohibitedStrings);
 
 function testProhibited(val, content) {
-  const re = new RegExp(`(\\.|@[a-z0-9/-]*)?\\b(${val.no})\\b(\\.\\w)?`, 'g');
+  let regexpString = '(\\.|@[a-z0-9/-]*)?';
+
+  // If it starts with a letter, make sure it is a word break.
+  if (/^\b/.test(val.no)) {
+    regexpString += '\\b';
+  }
+  regexpString += `(${val.no})`;
+
+  // If it ends with a letter, make sure it is a word break.
+  if (/\b$/.test(val.no)) {
+    regexpString += '\\b';
+  }
+  regexpString += '(\\.\\w)?';
+  const re = new RegExp(regexpString, 'g');
 
   let result = null;
   while (result = re.exec(content)) {

--- a/test.js
+++ b/test.js
@@ -154,5 +154,19 @@ test('remark-lint-prohibited-strings', (t) => {
       'should ignore strings in code fences'
     );
   }
+
+  {
+    const contents = "for Node.js' stuff\n\nand Node.js's stuff too";
+    t.deepEqual(
+      processorWithOptions([{ no: "Node\\.js's?", yes: 'the Node.js' }])
+        .processSync(vfile({ path: path, contents: contents }))
+        .messages.map(String),
+      [
+        'fhqwhgads.md:1:1-1:19: Use "the Node.js" instead of "Node.js\'"',
+        'fhqwhgads.md:3:1-3:24: Use "the Node.js" instead of "Node.js\'s"'
+      ],
+      'should allow flagging of apostrophes as final characters in "no" string'
+    );
+  }
   t.end();
 });


### PR DESCRIPTION
Forbidding "Node.js'" should also forbid "Node.js's".