### PR TITLE
feat: make `yes` configuration optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Example configuration:
 `no` is a string specifying the string you wish to prohibit. Regular expression
 characters are respected.
 
-`yes` is a string specifying what someone will be told to use instead.
+`yes` is a string specifying what someone will be told to use instead. It is
+optional.
 
 `ignoreNextTo` is a string that will make a prohibited string allowable if it
 appears next to that string. For example, in the configuration above, _gatsby_

--- a/index.js
+++ b/index.js
@@ -13,8 +13,8 @@ module.exports = rule('remark-lint:prohibited-strings', prohibitedStrings);
 function testProhibited(val, content) {
   let regexpString = '(\\.|@[a-zA-Z0-9/-]*)?';
 
-  // eslint-disable-next-line max-len
-  const ignoreNextTo = val.ignoreNextTo ? escapeStringRegexp(val.ignoreNextTo) : '';
+  const ignoreNextTo =
+    val.ignoreNextTo ? escapeStringRegexp(val.ignoreNextTo) : '';
 
   // If it starts with a letter, make sure it is a word break.
   if (/^\b/.test(val.no)) {
@@ -61,7 +61,9 @@ function prohibitedStrings(ast, file, strings) {
       const results = testProhibited(val, content);
       if (results.length) {
         results.forEach(({ result, index }) => {
-          file.message(`Use "${val.yes}" instead of "${result}"`, {
+          const message = val.yes ? `Use "${val.yes}" instead of "${result}"` :
+            `Do not use "${result}"`;
+          file.message(message, {
             start: location.toPosition(initial + index),
             end: location.toPosition(initial + index + [...result].length)
           });

--- a/test.js
+++ b/test.js
@@ -270,5 +270,16 @@ test('remark-lint-prohibited-strings', (t) => {
       'should still match on word boundaries with ignoreNextTo'
     );
   }
+
+  {
+    const contents = 'You got Sblounchsked!';
+    t.deepEqual(
+      processorWithOptions([{ no: 'Sblounchsked' }])
+          .processSync(vfile({ path: path, contents: contents }))
+        .messages.map(String),
+      [ 'fhqwhgads.md:1:9-1:21: Do not use "Sblounchsked"' ],
+      'should permit omitting the yes option'
+    );
+  }
   t.end();
 });


### PR DESCRIPTION
Refs: https://github.com/Trott/remark-lint-prohibited-strings/issues/40#issuecomment-619331779